### PR TITLE
feat: Add informative landing page for wiki plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "run-p type-check \"build-only {@}\" --",
     "preview": "vite preview",
     "test:unit": "vitest",
-    "build-only": "vite build",
+    "build-only": "vite build && cp public/plugin-info.html server/views/index.html",
     "type-check": "vue-tsc --build --force",
     "lint": "eslint . --fix",
     "lint:fix": "eslint . --fix",

--- a/public/plugin-info.html
+++ b/public/plugin-info.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TopLocs Wiki Plugin</title>
+    <link rel="icon" href="./favicon.ico">
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            background-color: #f8f9fa;
+        }
+        
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 2rem;
+        }
+        
+        header {
+            text-align: center;
+            margin-bottom: 3rem;
+        }
+        
+        h1 {
+            font-size: 2.5rem;
+            color: #2c3e50;
+            margin-bottom: 1rem;
+        }
+        
+        .subtitle {
+            font-size: 1.2rem;
+            color: #7f8c8d;
+        }
+        
+        .section {
+            background: white;
+            padding: 2rem;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            margin-bottom: 2rem;
+        }
+        
+        h2 {
+            color: #2c3e50;
+            margin-bottom: 1rem;
+            font-size: 1.5rem;
+        }
+        
+        .code-block {
+            background: #f4f4f4;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            padding: 1rem;
+            margin: 1rem 0;
+            overflow-x: auto;
+            font-family: 'Courier New', monospace;
+        }
+        
+        .highlight {
+            background: #e8f4ff;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: monospace;
+        }
+        
+        .links {
+            display: flex;
+            gap: 1rem;
+            margin-top: 2rem;
+            flex-wrap: wrap;
+        }
+        
+        .link-button {
+            display: inline-block;
+            padding: 0.75rem 1.5rem;
+            background: #3498db;
+            color: white;
+            text-decoration: none;
+            border-radius: 5px;
+            transition: background 0.3s;
+        }
+        
+        .link-button:hover {
+            background: #2980b9;
+        }
+        
+        .link-button.secondary {
+            background: #95a5a6;
+        }
+        
+        .link-button.secondary:hover {
+            background: #7f8c8d;
+        }
+        
+        ul {
+            margin-left: 2rem;
+            margin-top: 0.5rem;
+        }
+        
+        .feature-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 1rem;
+            margin-top: 1rem;
+        }
+        
+        .feature {
+            padding: 1rem;
+            background: #f8f9fa;
+            border-radius: 4px;
+        }
+        
+        .feature h3 {
+            color: #34495e;
+            margin-bottom: 0.5rem;
+        }
+        
+        .status-badge {
+            display: inline-block;
+            padding: 0.25rem 0.75rem;
+            background: #f39c12;
+            color: white;
+            border-radius: 20px;
+            font-size: 0.875rem;
+            margin-left: 1rem;
+        }
+        
+        @media (max-width: 600px) {
+            .container {
+                padding: 1rem;
+            }
+            
+            h1 {
+                font-size: 2rem;
+            }
+            
+            .section {
+                padding: 1.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>📝 TopLocs Wiki Plugin</h1>
+            <p class="subtitle">Collaborative wiki functionality for TopLocs communities</p>
+            <span class="status-badge">Hybrid Architecture</span>
+        </header>
+
+        <div class="section">
+            <h2>About</h2>
+            <p>The Wiki Plugin provides collaborative wiki functionality for TopLocs communities. It allows users to create, edit, and share wiki pages within their spheres using rich text editing capabilities.</p>
+            
+            <div class="feature-grid">
+                <div class="feature">
+                    <h3>✏️ Rich Text Editing</h3>
+                    <p>Full-featured editor with formatting options powered by Tiptap</p>
+                </div>
+                <div class="feature">
+                    <h3>🔄 Real-time Collaboration</h3>
+                    <p>Collaborative editing with Gun.js P2P synchronization</p>
+                </div>
+                <div class="feature">
+                    <h3>📂 Page Management</h3>
+                    <p>Organize wiki pages with tabs and hierarchical structure</p>
+                </div>
+                <div class="feature">
+                    <h3>📜 Version History</h3>
+                    <p>Track changes and revert to previous versions (planned)</p>
+                </div>
+            </div>
+        </div>
+
+        <div class="section">
+            <h2>Architecture Status</h2>
+            <p>The Wiki Plugin is currently in a <strong>hybrid architecture</strong> state, combining P2P capabilities with backend services:</p>
+            <ul>
+                <li><strong>P2P Layer:</strong> Gun.js for real-time collaboration</li>
+                <li><strong>Backend:</strong> Express.js + PostgreSQL for persistence</li>
+                <li><strong>Migration Progress:</strong> ⭐⭐⭐ Most advanced P2P integration</li>
+                <li><strong>Active Branch:</strong> <span class="highlight">gun</span> branch for full P2P features</li>
+            </ul>
+        </div>
+
+        <div class="section">
+            <h2>Integration</h2>
+            <p>To use this plugin in your TopLocs instance, add it to your plugin configuration:</p>
+            
+            <div class="code-block">
+{
+  "id": "wiki_plugin",
+  "name": "Wiki",
+  "url": "https://toplocs.github.io/wiki-plugin/server/views/assets/plugin.js",
+  "version": "1.0.0",
+  "description": "Collaborative wiki functionality for TopLocs communities",
+  "author": "TopLocs Team"
+}</div>
+            
+            <p>The plugin exposes components for the following slots:</p>
+            <ul>
+                <li><span class="highlight">WikiView</span> - Main wiki interface</li>
+                <li><span class="highlight">WikiCreate</span> - Wiki page creation</li>
+                <li><span class="highlight">Sidebar</span> - Wiki navigation sidebar</li>
+            </ul>
+        </div>
+
+        <div class="section">
+            <h2>Plugin Endpoints</h2>
+            <p>The plugin is served via GitHub Pages with the following key endpoints:</p>
+            <ul>
+                <li><strong>Plugin Entry:</strong> <span class="highlight">https://toplocs.github.io/wiki-plugin/server/views/assets/plugin.js</span></li>
+                <li><strong>Landing Page:</strong> <span class="highlight">https://toplocs.github.io/wiki-plugin/</span></li>
+            </ul>
+        </div>
+
+        <div class="section">
+            <h2>Development</h2>
+            <p>The Wiki Plugin is built with:</p>
+            <ul>
+                <li>Vue 3 + TypeScript</li>
+                <li>Tiptap Editor for rich text editing</li>
+                <li>Gun.js for P2P data synchronization</li>
+                <li>Express.js + Prisma + PostgreSQL (backend)</li>
+                <li>Vite + Module Federation</li>
+                <li>Tailwind CSS for styling</li>
+            </ul>
+            
+            <p>To run locally:</p>
+            <div class="code-block">
+# Clone the repository
+git clone https://github.com/toplocs/wiki-plugin.git
+cd wiki-plugin
+
+# Install dependencies
+npm install
+
+# Run development server
+npm run dev
+
+# For P2P development, use the gun branch
+git checkout gun</div>
+        </div>
+
+        <div class="section">
+            <h2>Resources</h2>
+            <div class="links">
+                <a href="https://github.com/toplocs/wiki-plugin" class="link-button">
+                    GitHub Repository
+                </a>
+                <a href="https://github.com/toplocs/tribelike" class="link-button secondary">
+                    TopLocs Platform
+                </a>
+                <a href="https://toplocs.github.io/toplocs-workspace/" class="link-button secondary">
+                    Documentation
+                </a>
+            </div>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Adds a professional landing page for the Wiki Plugin that provides information about the plugin, integration instructions, and links to resources.

## Features
- 📋 **Plugin Overview**: Description of wiki capabilities and hybrid architecture status
- 🔧 **Integration Guide**: Code examples for adding the plugin to TopLocs
- 🔗 **Resource Links**: Quick access to GitHub, documentation, and platform
- 📱 **Responsive Design**: Works well on all device sizes
- 🎨 **Professional Styling**: Clean, modern design matching TopLocs aesthetic
- 🏷️ **Status Badge**: Shows current architecture state (Hybrid)

## Changes
- Add `public/plugin-info.html` with the landing page content
- Update build script to copy landing page to `server/views/index.html` after build
- Add `.nojekyll` file for proper GitHub Pages deployment
- Landing page includes:
  - Feature grid (Rich Text Editing, Real-time Collaboration, Page Management, Version History)
  - Architecture status explanation
  - Integration instructions with JSON config
  - Plugin endpoints documentation
  - Development setup instructions

## Preview
Once deployed, the landing page will be available at:
- https://toplocs.github.io/wiki-plugin/

While the plugin entry point remains at:
- https://toplocs.github.io/wiki-plugin/server/views/assets/plugin.js

🤖 Generated with [Claude Code](https://claude.ai/code)