### PR TITLE
fix: configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,73 @@
+name: Deploy Wiki Plugin to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+          
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+          
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+          
+      - name: Install dependencies
+        run: pnpm install
+          
+      - name: Build plugin
+        run: pnpm build
+          
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "VITE_DEV=true vite --port 3006 --open",
-    "build": "run-p type-check \"build-only {@}\" -- && mv dist/landing.html dist/index.html",
+    "build": "run-p type-check \"build-only {@}\" -- && mv dist/landing.html dist/index.html && touch dist/.nojekyll",
     "preview": "vite preview",
     "test:unit": "vitest",
     "build-only": "vite build",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ import tailwindcss from 'tailwindcss';
 import autoprefixer from 'autoprefixer';
 
 export default defineConfig({
+  base: './',
   plugins: [
     vue(),
     federation({


### PR DESCRIPTION
## Summary
- Configure Vite for relative paths with `base: './'`
- Add `.nojekyll` file creation to prevent Jekyll processing
- Include GitHub Actions workflow for automated deployment

## Test plan
- [x] Verify build script creates `.nojekyll` file
- [x] Confirm vite.config.ts has correct base path
- [x] Check GitHub Actions workflow matches link-plugin configuration
- [ ] Test deployment to GitHub Pages after merge

🤖 Generated with [Claude Code](https://claude.ai/code)