### PR TITLE
feat: Use dynamic URLs in InfoPage instead of hardcoded localhost

### DIFF
--- a/src/InfoPage.vue
+++ b/src/InfoPage.vue
@@ -51,10 +51,14 @@ const features = [
   }
 ]
 
+// Compute base URL from current location
+const baseUrl = window.location.origin + window.location.pathname.replace(/\/[^/]*$/, '')
+const isDevelopment = window.location.hostname === 'localhost'
+
 const endpoints = {
-  plugin: 'http://localhost:3006/assets/plugin.js',
-  landing: 'https://toplocs.github.io/wiki-plugin',
-  demo: 'http://localhost:3000'
+  plugin: `${baseUrl}/assets/plugin.js`,
+  landing: baseUrl,
+  demo: 'https://toplocs.github.io/tribelike/'
 }
 
 const development = {
@@ -62,7 +66,7 @@ const development = {
   setup: `pnpm install && pnpm dev`,
   urls: [
     { label: 'GitHub Repository', url: 'https://github.com/toplocs/wiki-plugin' },
-    { label: 'Plugin Development', url: 'http://localhost:3006' }
+    { label: isDevelopment ? 'Local Development' : 'Plugin Landing Page', url: baseUrl }
   ]
 }
 


### PR DESCRIPTION
## Summary
- Replace hardcoded localhost URLs with dynamically computed URLs based on window.location
- Automatically detect development vs production environment
- Makes plugin work correctly regardless of deployment location (GitHub Pages, custom domains, local dev)

## Changes
- Compute base URL from `window.location.origin + window.location.pathname`
- Use environment detection (`window.location.hostname === 'localhost'`) for development-specific labels
- Update demo URL to point to deployed tribelike instance at https://toplocs.github.io/tribelike/

## Benefits
- Plugins will work correctly whether deployed to GitHub Pages, custom domains, or local development
- No need to update URLs when changing deployment locations
- Development and production URLs automatically adjust
- Future-proof for any deployment scenario

🤖 Generated with [Claude Code](https://claude.ai/code)