### PR TITLE
fix: Remove assets folder from build output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,12 @@ interface ExtendedPluginConfig extends BasePluginConfig {
   tabs?: Array<{ value: string; href: string }>;
 }
 
+const baseUrl = window.location.origin + window.location.pathname.replace(/\/[^/]*$/, '')
+
 const pluginConfig: ExtendedPluginConfig = {
   id: 'wiki_plugin',
   name: 'Wiki',
-  url: 'https://toplocs.github.io/wiki-plugin/assets/plugin.js',
+  url: `${baseUrl}/plugin.js`,
   version: '1.0.0',
   description: 'Share and organize wikis within TopLocs spheres',
   author: 'TopLocs Team',

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ interface ExtendedPluginConfig extends BasePluginConfig {
 const pluginConfig: ExtendedPluginConfig = {
   id: 'wiki_plugin',
   name: 'Wiki',
-  url: 'http://localhost:3006/assets/plugin.js',
+  url: 'https://toplocs.github.io/wiki-plugin/assets/plugin.js',
   version: '1.0.0',
   description: 'Share and organize wikis within TopLocs spheres',
   author: 'TopLocs Team',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -63,6 +63,8 @@ export default defineConfig({
     target: 'esnext',
     minify: false,
     cssCodeSplit: false,
+    outDir: './dist',
+    assetsDir: '',
     rollupOptions: {
       input: {
         main: path.resolve(__dirname, 'index.html'),


### PR DESCRIPTION
## Summary
- Aligns build configuration with link-plugin by removing the assets folder
- Changes plugin entry point from `/assets/plugin.js` to `/plugin.js`
- Sets `assetsDir: ''` and adds explicit `outDir: './dist'` in vite.config.ts

## Test plan
- [ ] Build the plugin with `pnpm build`
- [ ] Verify `dist/plugin.js` is created (not `dist/assets/plugin.js`)
- [ ] Update plugin URL in TopLocs to `https://toplocs.github.io/wiki-plugin/plugin.js`

🤖 Generated with [Claude Code](https://claude.ai/code)